### PR TITLE
feat: add Hermes Agent with OpenRouter to romeo-2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -211,6 +211,27 @@
     "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
           "lanzaboote",
           "nixpkgs"
         ]
@@ -229,7 +250,7 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
           "nixvim",
@@ -250,7 +271,7 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
           "nur",
@@ -271,7 +292,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
           "system-manager",
@@ -432,6 +453,30 @@
         "type": "github"
       }
     },
+    "hermes-agent": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix_2",
+        "uv2nix": "uv2nix_2"
+      },
+      "locked": {
+        "lastModified": 1776195050,
+        "narHash": "sha256-dM7EDKIRbmhjfLi+RZDb0/Okr/VMMT8DdaKGbg90guM=",
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "rev": "95d11dfd8e6e86e97657598450efe065f33e9cdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -500,7 +545,7 @@
       "inputs": {
         "crane": "crane",
         "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
@@ -773,7 +818,7 @@
     },
     "nixvim": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_4",
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
@@ -827,7 +872,7 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_5",
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
@@ -945,6 +990,94 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "c37f66a953535c394244888598947679af231863",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769936401,
+        "narHash": "sha256-kwCOegKLZJM9v/e/7cqwg1p/YjjTAukKPqmxKnAZRgA=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "b0d513eeeebed6d45b4f2e874f9afba2021f7812",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772865871,
+        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "uv2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771518446,
+        "narHash": "sha256-nFJSfD89vWTu92KyuJWDoTQJuoDuddkJV3TlOl1cOic=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "eb204c6b3335698dec6c7fc1da0ebc3c6df05937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agenix": "agenix",
@@ -952,6 +1085,7 @@
         "agenix-template": "agenix-template",
         "disko": "disko",
         "flake-utils-plus": "flake-utils-plus",
+        "hermes-agent": "hermes-agent",
         "home-manager-unstable": "home-manager-unstable",
         "jellyswarrm": "jellyswarrm",
         "lanzaboote": "lanzaboote",
@@ -1194,7 +1328,7 @@
           "system-manager",
           "flake-compat"
         ],
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "nixpkgs": [
           "system-manager",
           "nixpkgs"
@@ -1214,6 +1348,55 @@
         "owner": "jfroche",
         "ref": "system-manager",
         "repo": "userborn",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770770348,
+        "narHash": "sha256-A2GzkmzdYvdgmMEu5yxW+xhossP+txrYb7RuzRaqhlg=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "5d1b2cb4fe3158043fbafbbe2e46238abbc954b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    },
+    "uv2nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix_3"
+      },
+      "locked": {
+        "lastModified": 1773039484,
+        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,11 @@
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
 
+    hermes-agent = {
+      url = "github:NousResearch/hermes-agent";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
+
     system-manager = {
       url = "github:numtide/system-manager";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
@@ -137,7 +142,14 @@
           nixosMods = inputs.nixpkgs-unstable + "/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares.nix";
           desktop = "kde6";
         };
-        "romeo-2" = libx.mkHost { hostname = "romeo-2"; usernames = [ "bcnelson" ]; nixosMods = inputs.jellyswarrm.nixosModules.default; };
+        "romeo-2" = libx.mkHost {
+          hostname = "romeo-2";
+          usernames = [ "bcnelson" ];
+          nixosMods = [
+            inputs.jellyswarrm.nixosModules.default
+            inputs.hermes-agent.nixosModules.default
+          ];
+        };
         "whiskey-1" = libx.mkHost { hostname = "whiskey-1"; usernames = [ "bcnelson" ]; nixosMods = inputs.disko.nixosModules.disko; };
         "vor-2" = libx.mkHost { hostname = "vor-2"; usernames = [ "bcnelson" ]; };
       };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -89,7 +89,7 @@ in
       # Always use home-manager-unstable regardless of nixpkgs version
       inputs.home-manager-unstable.nixosModules.home-manager
       (mkHome { inherit hostname usernames desktop; })
-    ] ++ (if nixosMods != null then [ nixosMods ] else []);
+    ] ++ (if nixosMods != null then (if builtins.isList nixosMods then nixosMods else [ nixosMods ]) else []);
   };
 
 

--- a/nixos/romeo/services/default.nix
+++ b/nixos/romeo/services/default.nix
@@ -17,6 +17,7 @@
     ./jellyswarrm.nix
     ./immich.nix
     ./immichframe.nix
+    ./hermes-agent.nix
   ];
 
   systemd.timers.podman-auto-update = {

--- a/nixos/romeo/services/hermes-agent.nix
+++ b/nixos/romeo/services/hermes-agent.nix
@@ -1,0 +1,60 @@
+{ config, ... }:
+let
+  dataDirs = config.data.dirs;
+in
+{
+  age.secrets.openrouter-api-key = {
+    rekeyFile = ./secrets/openrouter_api_key.age;
+  };
+
+  age-template.files.hermes-agent-env = {
+    vars = {
+      OPENROUTER_API_KEY = config.age.secrets.openrouter-api-key.path;
+    };
+    content = ''
+      OPENROUTER_API_KEY=$OPENROUTER_API_KEY
+    '';
+  };
+
+  services.hermes-agent = {
+    enable = true;
+    stateDir = "${dataDirs.level5}/hermes-agent";
+    addToSystemPackages = true;
+
+    environmentFiles = [
+      config.age-template.files.hermes-agent-env.path
+    ];
+
+    settings = {
+      model = {
+        default = "nousresearch/hermes-3-llama-3.1-405b";
+        base_url = "https://openrouter.ai/api/v1";
+      };
+      smart_model_routing = {
+        enabled = true;
+        max_simple_chars = 160;
+        max_simple_words = 28;
+        cheap_model = {
+          provider = "ollama";
+          model = "qwen3:4b";
+          base_url = "http://127.0.0.1:11434/v1";
+        };
+      };
+      toolsets = [ "all" ];
+      terminal = {
+        backend = "local";
+        timeout = 180;
+      };
+      memory = {
+        memory_enabled = true;
+        user_profile_enabled = true;
+      };
+    };
+  };
+
+  systemd.services.hermes-agent = {
+    after = [ "zfs-import.target" "ollama.service" ];
+    requires = [ "zfs-import.target" ];
+    wants = [ "ollama.service" ];
+  };
+}


### PR DESCRIPTION
## Summary
- Add NousResearch Hermes Agent service to romeo-2
- OpenRouter as primary LLM (hermes-3-405b), smart routing sends simple queries to local Ollama on B580 GPU (qwen3:4b)
- Make `mkHost` accept list-valued `nixosMods` (backward-compatible)
- Agenix secret for OpenRouter API key

## Before deploy
- [ ] Provision OpenRouter API key via `agenix-rekey`
- [ ] Verify gateway port for nginx proxy setup

## Test plan
- [ ] `nix build .#nixosConfigurations.romeo-2.config.system.build.toplevel --dry-run` (requires .age file)
- [ ] Deploy to romeo-2, verify `systemctl status hermes-agent`
- [ ] Test `hermes chat` with OpenRouter model
- [ ] Test smart routing routes simple queries to local Ollama