### PR TITLE
Pin happy-coder to monorepo migration PR and wire HAPPY_CLAUDE_PATH

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -675,6 +675,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-happy-coder": {
+      "locked": {
+        "lastModified": 1777745641,
+        "narHash": "sha256-dbc8VuxY2zMr8xot6mY8+xg23iQ8dNMLMUK9dQgouMc=",
+        "owner": "colonelpanic8",
+        "repo": "nixpkgs",
+        "rev": "f74f4e07652a690834d5e02b3507607dc5a24698",
+        "type": "github"
+      },
+      "original": {
+        "owner": "colonelpanic8",
+        "ref": "happy-coder-monorepo-migration",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1730741070,
@@ -962,6 +978,7 @@
         "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-happy-coder": "nixpkgs-happy-coder",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixpkgs-unstable-small": "nixpkgs-unstable-small",
         "nixvim": "nixvim",

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,9 @@
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-unstable-small.url = "github:nixos/nixpkgs/nixos-unstable-small";
 
+    # happy-coder PR #492656 — monorepo migration. Remove once merged into unstable.
+    nixpkgs-happy-coder.url = "github:colonelpanic8/nixpkgs/happy-coder-monorepo-migration";
+
     # Home manager - always use unstable
     home-manager-unstable.url = "github:nix-community/home-manager/master";
     home-manager-unstable.inputs.nixpkgs.follows = "nixpkgs-unstable";

--- a/home-manager/bcnelson/_mixins/happy/default.nix
+++ b/home-manager/bcnelson/_mixins/happy/default.nix
@@ -8,9 +8,11 @@ let
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
       wrapProgram $out/bin/happy \
-        --set-default HAPPY_HOME_DIR ${happyHomeDir}
+        --set-default HAPPY_HOME_DIR ${happyHomeDir} \
+        --set-default HAPPY_CLAUDE_PATH ${pkgs.claude-code-bin}/bin/claude
       wrapProgram $out/bin/happy-mcp \
-        --set-default HAPPY_HOME_DIR ${happyHomeDir}
+        --set-default HAPPY_HOME_DIR ${happyHomeDir} \
+        --set-default HAPPY_CLAUDE_PATH ${pkgs.claude-code-bin}/bin/claude
     '';
     inherit (pkgs.happy-coder) meta;
   };

--- a/modules/nixos/happy-daemon.nix
+++ b/modules/nixos/happy-daemon.nix
@@ -15,6 +15,8 @@ in
 
     authNotifyPackage = lib.mkPackageOption pkgs "happy-auth-notify" { };
 
+    claudePackage = lib.mkPackageOption pkgs "claude-code-bin" { };
+
     happyHomeDir = lib.mkOption {
       type = lib.types.str;
       default = "/home/${cfg.user}/.local/share/happy";
@@ -60,6 +62,7 @@ in
           Environment = [
             "HOME=/home/${cfg.user}"
             "HAPPY_HOME_DIR=${cfg.happyHomeDir}"
+            "HAPPY_CLAUDE_PATH=${cfg.claudePackage}/bin/claude"
           ];
           ExecStart = "${cfg.package}/bin/happy daemon start-sync";
           Restart = "on-failure";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,6 +9,22 @@
   # https://nixos.wiki/wiki/Overlays
   modifications = final: prev: {
     # libsForQt5.sddm = nixpkgs-unstable.libsForQt5.sddm;
+
+    # happy-coder PR #492656 — monorepo migration, pre-merge testing.
+    # Remove once the PR lands in nixpkgs-unstable.
+    # The PR's wrapper invokes node by absolute path but the CLI spawns child
+    # `node` processes via PATH lookup (e.g. `happy daemon start-sync`),
+    # so add nodejs to PATH here.
+    happy-coder = (inputs.nixpkgs-happy-coder.legacyPackages.${final.stdenv.hostPlatform.system}.happy-coder).overrideAttrs (old: {
+      nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ final.makeWrapper ];
+      postFixup = (old.postFixup or "") + ''
+        wrapProgram $out/bin/happy \
+          --prefix PATH : ${final.lib.makeBinPath [ final.nodejs ]}
+        wrapProgram $out/bin/happy-mcp \
+          --prefix PATH : ${final.lib.makeBinPath [ final.nodejs ]}
+      '';
+    });
+
     claude-code-bin = prev.claude-code-bin.overrideAttrs (oldAttrs: {
       postFixup = (oldAttrs.postFixup or "") + ''
         wrapProgram $out/bin/claude \


### PR DESCRIPTION
## Summary
- Track nixpkgs PR [#492656](https://github.com/NixOS/nixpkgs/pull/492656) (colonelpanic8/nixpkgs `happy-coder-monorepo-migration`) via a dedicated flake input and overlay until it lands in unstable.
- Overlay wraps `happy` / `happy-mcp` with `nodejs` on PATH because the CLI spawns child `node` processes via PATH lookup (e.g. `happy daemon start-sync`) — the upstream wrapper only points node at an absolute path for the entrypoint.
- Set `HAPPY_CLAUDE_PATH` on the happy wrappers (home-manager) and daemon (NixOS module) so happy-coder uses the pinned `claude-code-bin` instead of resolving `claude` from PATH.

## Test plan
- [ ] `just check-host <workstation>` — flake evaluates with the new input
- [ ] `nix build .#nixosConfigurations.<workstation>.config.system.build.toplevel --dry-run`
- [ ] Run `happy daemon start-sync` from a built profile and confirm it no longer fails on missing `node`
- [ ] Confirm `HAPPY_CLAUDE_PATH` resolves to the pinned `claude-code-bin/bin/claude`