### PR TITLE
Bound romeo shutdown to escape s6-svscan reboot hang

### DIFF
--- a/nixos/_mixins/roles/docker.nix
+++ b/nixos/_mixins/roles/docker.nix
@@ -10,6 +10,15 @@
     TimeoutStopSec = 30;
   };
 
+  # Bound shutdown so a hung container (e.g. orphaned s6-svscan from a
+  # linuxserver.io image after its volumes have unmounted) can't pin the box
+  # in systemd-shutdown forever — RebootWatchdogSec arms the hardware
+  # watchdog during the final reboot phase.
+  systemd.settings.Manager = {
+    DefaultTimeoutStopSec = "45s";
+    RebootWatchdogSec = "60s";
+  };
+
   environment.systemPackages = [
     pkgs.docker-compose
   ];

--- a/nixos/romeo/default.nix
+++ b/nixos/romeo/default.nix
@@ -56,7 +56,7 @@ in
       Type = "oneshot";
       RemainAfterExit = true;
       ExecStart = "${pkgs.coreutils}/bin/true";
-      ExecStop = "${services.networkBacked}/bin/dockerStack-general down";
+      ExecStop = "${services.networkBacked}/bin/dockerStack-general down -t 20";
       TimeoutStopSec = 30;
     };
   };

--- a/nixos/romeo/docker-services/defs/nextcloud.nix
+++ b/nixos/romeo/docker-services/defs/nextcloud.nix
@@ -10,6 +10,8 @@ in
       "PUID=1000"
       "PGID=1000"
       "TZ=America/Denver"
+      "S6_SERVICES_GRACETIME=5000"
+      "S6_KILL_GRACETIME=3000"
     ];
     volumes = [
       "${dataDirs.level5}/nextcloud/config:/config"

--- a/nixos/romeo/services/syncthing.nix
+++ b/nixos/romeo/services/syncthing.nix
@@ -19,9 +19,12 @@ in
       PUID = "1000";
       PGID = "1000";
       TZ = "America/Denver";
+      S6_SERVICES_GRACETIME = "5000";
+      S6_KILL_GRACETIME = "3000";
     };
     labels = {
       "io.containers.autoupdate" = "registry";
     };
+    extraOptions = [ "--stop-timeout=20" ];
   };
 }


### PR DESCRIPTION
## Summary

Romeo gets stuck on reboot in the final `systemd-shutdown` phase. The console shows:

```
watchdog: watchdog0: watchdog did not stop!
systemd-shutdown[1]: Waiting for process: 8761 (s6-svscan)
```

`s6-svscan` is the s6 supervision entrypoint baked into linuxserver.io images. Romeo runs two of those (syncthing as an OCI container, nextcloud in the docker-compose stack). One of them gets orphaned after its backing ZFS volumes have already been exported, ends up in uninterruptible sleep, and pins PID 1 — and the repo had no `RebootWatchdogSec` to force the box through.

Two-layer fix:

- **Bounded shutdown (safety net)** — `nixos/_mixins/roles/docker.nix` now sets `systemd.settings.Manager` with `RebootWatchdogSec=60s` and `DefaultTimeoutStopSec=45s`. If shutdown ever hangs again, the hardware watchdog forces the reboot within ~60s. Applies to every docker-using host.
- **Container hardening (root cause)** — syncthing and nextcloud get `S6_SERVICES_GRACETIME=5000` + `S6_KILL_GRACETIME=3000` so s6-overlay exits faster, plus `--stop-timeout=20` on the syncthing OCI container and `-t 20` on the compose stack's `down` so docker also won't wait forever.

`systemd.extraConfig` is deprecated in current nixpkgs (caught on first build); switched to `systemd.settings.Manager`.

## Test plan

- [x] `just check-host romeo-2` passes
- [ ] Deploy to romeo (`just sync` or equivalent)
- [ ] After deploy, confirm settings landed:
  - `systemctl show --property=DefaultTimeoutStopSec,RebootWatchdogSec` → 45s / 60s
  - `docker inspect syncthing --format '{{.HostConfig.StopTimeout}}'` → 20
- [ ] Real reboot from console (not SSH — hang happens after networking dies). With the fix, either the `Waiting for process` line never appears, or it does and the watchdog forces reboot within 60s instead of hanging indefinitely.
- [ ] Optional: identify the actual culprit container with `docker top` looking for `s6-svscan` before triggering the reboot.