### PR TITLE
Wire OIDC SSO for cadence via Kanidm

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -106,11 +106,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780636547,
-        "narHash": "sha256-VYcJquTizHc6w6sm0hxTPkWJ8Z4D5XZaQxp38a2BcVI=",
+        "lastModified": 1780641444,
+        "narHash": "sha256-qieA5GfTzSIMrp6uX+RYLfHFjtOsn/egGg/4sIHsC4c=",
         "owner": "BCNelson",
         "repo": "cadence",
-        "rev": "8eb961f1da6fdab82e987a5bacb1063aef9b6a9c",
+        "rev": "14cc4b6144cf99aec5451d16625ac5c5bd0b7353",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -106,11 +106,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780641444,
-        "narHash": "sha256-qieA5GfTzSIMrp6uX+RYLfHFjtOsn/egGg/4sIHsC4c=",
+        "lastModified": 1780643109,
+        "narHash": "sha256-OUx/ajrpG9DYVAjO7odQrEV7HJ1YFRyEAG34GHjRMR4=",
         "owner": "BCNelson",
         "repo": "cadence",
-        "rev": "14cc4b6144cf99aec5451d16625ac5c5bd0b7353",
+        "rev": "6bcdf0fbbba1013982181b874f1ac79e55afd148",
         "type": "github"
       },
       "original": {

--- a/nixos/whiskey/services/cadence.nix
+++ b/nixos/whiskey/services/cadence.nix
@@ -1,18 +1,8 @@
-{ config, inputs, pkgs, ... }:
+{ config, inputs, ... }:
 let
   dataDirs = {
     level3 = "/data/level3"; # High
   };
-  # The cadence NixOS module's typed `settings` schema doesn't yet expose
-  # `server.oidc` (added in the daemon at 14cc4b6). Use the documented
-  # `extraConfigFiles` escape hatch — the daemon merges YAML over `settings`.
-  oidcConfig = pkgs.writeText "cadence-oidc.yaml" ''
-    server:
-      oidc:
-        issuer: https://idm.nel.family/oauth2/openid/cadence
-        client_id: cadence
-        tier: read_write
-  '';
 in
 {
   imports = [ inputs.cadence.nixosModules.cadence ];
@@ -53,8 +43,12 @@ in
         base_url = "https://health.b.nel.family";
         uuid_salt = "\${env:CADENCE_UUID_SALT}";
         api_keys.read_write = [ "\${env:CADENCE_API_RW_KEY}" ];
+        oidc = {
+          issuer = "https://idm.nel.family/oauth2/openid/cadence";
+          client_id = "cadence";
+          tier = "read_write";
+        };
       };
     };
-    extraConfigFiles = [ oidcConfig ];
   };
 }

--- a/nixos/whiskey/services/cadence.nix
+++ b/nixos/whiskey/services/cadence.nix
@@ -1,8 +1,18 @@
-{ config, inputs, ... }:
+{ config, inputs, pkgs, ... }:
 let
   dataDirs = {
     level3 = "/data/level3"; # High
   };
+  # The cadence NixOS module's typed `settings` schema doesn't yet expose
+  # `server.oidc` (added in the daemon at 14cc4b6). Use the documented
+  # `extraConfigFiles` escape hatch — the daemon merges YAML over `settings`.
+  oidcConfig = pkgs.writeText "cadence-oidc.yaml" ''
+    server:
+      oidc:
+        issuer: https://idm.nel.family/oauth2/openid/cadence
+        client_id: cadence
+        tier: read_write
+  '';
 in
 {
   imports = [ inputs.cadence.nixosModules.cadence ];
@@ -45,5 +55,6 @@ in
         api_keys.read_write = [ "\${env:CADENCE_API_RW_KEY}" ];
       };
     };
+    extraConfigFiles = [ oidcConfig ];
   };
 }

--- a/nixos/whiskey/services/kanidm.nix
+++ b/nixos/whiskey/services/kanidm.nix
@@ -275,6 +275,16 @@
           basicSecretFile = config.age.secrets.journiv-oauth-client-secret.path;
           preferShortUsername = true;
         };
+        "cadence" = {
+          displayName = "Cadence";
+          originUrl = "https://health.b.nel.family/callback";
+          originLanding = "https://health.b.nel.family/";
+          scopeMaps = {
+            "service_admins" = [ "email" "openid" "profile" ];
+          };
+          public = true;
+          preferShortUsername = true;
+        };
       };
       persons = {
         "bcnelson" = {


### PR DESCRIPTION
## Summary
- Bump `cadence` flake input to `14cc4b6` — adds OIDC SSO alongside API-key auth (`feat(auth): add OIDC SSO alongside API-key auth`).
- Register `cadence` as a public PKCE OAuth2 client in the local Kanidm IdP, scoped to `service_admins`. No `client_secret` needed: the daemon validates Bearer tokens directly against `.well-known/openid-configuration`, and the SPA acquires tokens via auth-code + PKCE.
- Route `server.oidc` config via `extraConfigFiles` because the cadence NixOS module's typed `settings` schema doesn't yet expose the new keys; the daemon merges YAML over `settings`.

OIDC config:
- issuer: `https://idm.nel.family/oauth2/openid/cadence`
- client_id: `cadence`
- tier: `read_write` (signed-in admins can edit checks)

## Test plan
- [x] `nix build .#nixosConfigurations.whiskey-1.config.system.build.toplevel --dry-run` succeeds.
- [ ] Deploy to whiskey (`just update-os` on whiskey, or `just sync`).
- [ ] Visit https://health.b.nel.family — login button redirects to `idm.nel.family`, callback at `/callback` lands signed in.
- [ ] Existing API-key auth still works (legacy `${env:CADENCE_API_RW_KEY}` path unchanged).