### PR TITLE
Create journiv data dirs declaratively on romeo

### DIFF
--- a/nixos/romeo/services/journiv.nix
+++ b/nixos/romeo/services/journiv.nix
@@ -162,6 +162,15 @@ in
     };
   };
 
+  systemd.tmpfiles.rules = [
+    "d ${dataDirs.level2}/journiv          0755 root root - -"
+    "d ${dataDirs.level2}/journiv/postgres 0755 root root - -"
+    "d ${dataDirs.level3}/journiv          0755 root root - -"
+    "d ${dataDirs.level3}/journiv/data     0755 root root - -"
+    "d ${dataDirs.level7}/journiv          0755 root root - -"
+    "d ${dataDirs.level7}/journiv/valkey   0755 root root - -"
+  ];
+
   systemd.services.podman-journiv-valkey.serviceConfig.ExecStartPre = [
     "-${pkgs.podman}/bin/podman network create ${appNetwork}"
   ];


### PR DESCRIPTION
## Summary
- `podman-journiv-valkey` was failing with exit 125 because `/cache/journiv/valkey` did not exist; postgres/app/worker/beat all failed with `dependency` errors. After 5 quick restarts the unit hit `start-limit-hit` and stayed dead.
- The postgres (`level2`) and app (`level3`) bind-mount targets were also missing — same class of bug, waiting to bite once valkey was fixed.
- Added `systemd.tmpfiles.rules` to `nixos/romeo/services/journiv.nix` so all three data-dir trees exist before the containers start. No other deploy surface changes.

## Test plan
- [x] `nix build .#nixosConfigurations.romeo-2.config.system.build.toplevel --dry-run` succeeds
- [ ] After auto-update lands on romeo: `/cache/journiv/valkey`, `/mnt/vault/data/level2/journiv/postgres`, `/mnt/vault/data/level3/journiv/data` exist
- [ ] `systemctl reset-failed podman-journiv-valkey` (start-limit may still be in effect from before this change) then verify the full chain — valkey → postgres → app → worker → beat — comes up
- [ ] `journal.nel.family` loads