### PR TITLE
Chown journiv app data dir to UID 1000 for appuser

### DIFF
--- a/nixos/romeo/services/journiv.nix
+++ b/nixos/romeo/services/journiv.nix
@@ -166,7 +166,7 @@ in
     "d ${dataDirs.level2}/journiv          0755 root root - -"
     "d ${dataDirs.level2}/journiv/postgres 0755 root root - -"
     "d ${dataDirs.level3}/journiv          0755 root root - -"
-    "d ${dataDirs.level3}/journiv/data     0755 root root - -"
+    "d ${dataDirs.level3}/journiv/data     0755 1000 1000 - -"
     "d ${dataDirs.level7}/journiv          0755 root root - -"
     "d ${dataDirs.level7}/journiv/valkey   0755 root root - -"
   ];


### PR DESCRIPTION
## Summary
- Follow-up to #40. After the dirs were created, `podman-journiv-app` still crash-looped:
  ```
  Ensuring data directories exist...
  mkdir: cannot create directory '/data/media': Permission denied
  mkdir: cannot create directory '/data/logs':  Permission denied
  ```
- The `swalabtech/journiv-app:latest` image runs as `appuser` (Debian `adduser` default = UID 1000) and its entrypoint mkdir's subdirs inside `/data`. With the host dir at `root:root 0755` from #40, those mkdirs failed and the container exited before serving anything.
- Change only the level3 `journiv/data` tmpfiles rule to own UID 1000:1000. valkey/postgres dirs stay root-owned — their entrypoints run as root and chown themselves; both are confirmed healthy on romeo right now.

## Test plan
- [x] `nix build .#nixosConfigurations.romeo-2.config.system.build.toplevel --dry-run` succeeds
- [ ] After auto-update lands on romeo: `/mnt/vault/data/level3/journiv/data` is owned `1000:1000`
- [ ] `systemctl reset-failed podman-journiv-app podman-journiv-worker podman-journiv-beat` (start-limit may still be in effect), then verify full chain — valkey → postgres → app → worker → beat — is `active (running)`
- [ ] `journal.nel.family` loads