### PR TITLE
Add authentik blueprints for recovery email and invitation onboarding

### DIFF
--- a/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
+++ b/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
@@ -270,8 +270,8 @@ entries:
   ##########################################################################
   # Standing multi-use registration link.
   #
-  # A single invitation that as many people as you like can use to self-register,
-  # valid until `expires`. Share the URL:
+  # A single invitation that as many people as you like can use to self-register.
+  # Share the URL:
   #
   #   https://auth.nel.family/if/flow/nel-family-enrollment/?itoken=<uuid>
   #
@@ -280,17 +280,25 @@ entries:
   # the invitation's primary key, assigned by authentik and stable across
   # blueprint re-applies).
   #
+  # state: created -> the blueprint only SEEDS this invitation the first time;
+  # it will not overwrite it afterwards. That means you can change the expiry
+  # (and single-use, etc.) directly in the admin UI -> Invitations ->
+  # nel-family-open-registration -> Edit, and your change sticks. The `expires`
+  # below is just the initial value used at first creation. (If you delete the
+  # invitation in the UI, the next blueprint apply re-seeds it with these values;
+  # to retire it for good, add `state: absent` here instead.)
+  #
   # fixed_data is empty, so the auto-email policy above intentionally skips it —
-  # no mail is sent when this invitation is (re)created.
+  # no mail is sent when this invitation is created.
   #
   # SECURITY: anyone holding this link can create an internal account while it is
-  # valid. To extend the window, bump `expires`. To revoke early, set `expires`
-  # to a past date or add `state: absent` to this entry and re-apply.
+  # valid. Shorten the expiry (or set it to the past) in the UI to revoke.
   ##########################################################################
   - identifiers:
       name: nel-family-open-registration
     id: invitation-open
     model: authentik_stages_invitation.invitation
+    state: created
     attrs:
       flow: !KeyOf flow
       single_use: false

--- a/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
+++ b/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
@@ -267,41 +267,8 @@ entries:
     attrs:
       enabled: true
 
-  ##########################################################################
-  # Standing multi-use registration link.
-  #
-  # A single invitation that as many people as you like can use to self-register.
-  # Share the URL:
-  #
-  #   https://auth.nel.family/if/flow/nel-family-enrollment/?itoken=<uuid>
-  #
-  # Grab the real URL once from the admin UI: Flows & Stages -> Invitations ->
-  # nel-family-open-registration -> "Link to use the invitation" (the <uuid> is
-  # the invitation's primary key, assigned by authentik and stable across
-  # blueprint re-applies).
-  #
-  # state: created -> the blueprint only SEEDS this invitation the first time;
-  # it will not overwrite it afterwards. That means you can change the expiry
-  # (and single-use, etc.) directly in the admin UI -> Invitations ->
-  # nel-family-open-registration -> Edit, and your change sticks. The `expires`
-  # below is just the initial value used at first creation. (If you delete the
-  # invitation in the UI, the next blueprint apply re-seeds it with these values;
-  # to retire it for good, add `state: absent` here instead.)
-  #
-  # fixed_data is empty, so the auto-email policy above intentionally skips it —
-  # no mail is sent when this invitation is created.
-  #
-  # SECURITY: anyone holding this link can create an internal account while it is
-  # valid. Shorten the expiry (or set it to the past) in the UI to revoke.
-  ##########################################################################
-  - identifiers:
-      name: nel-family-open-registration
-    id: invitation-open
-    model: authentik_stages_invitation.invitation
-    state: created
-    attrs:
-      flow: !KeyOf flow
-      single_use: false
-      expiring: true
-      expires: "2027-06-13T00:00:00Z"
-      fixed_data: {}
+  # No standing/seeded invitation is created here on purpose. Registration links
+  # are created on demand from the admin UI: Directory -> Invitations -> New
+  # Invitation -> select the "nel.family enrollment" flow, set Name / Expires /
+  # Single use, and (optionally) Custom attributes {"email": "..."} to trigger
+  # the auto-email policy above. Expand the row for "Link to use the invitation".

--- a/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
+++ b/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
@@ -1,0 +1,268 @@
+# Invitation-based onboarding with automatic email.
+#
+# This gives us two onboarding paths off a single enrollment flow:
+#
+#   1. Auto-emailed onboarding — an admin creates an invitation (Directory ->
+#      Invitations, or Flows & Stages -> Invitations) and fills the "Custom
+#      attributes" with at least {"email": "person@example.com"} (optionally
+#      "name" / "username"). The expression policy below fires on the
+#      invitation's model_created event and emails that person their personal
+#      onboarding link via the global Migadu SMTP. Zero extra admin clicks.
+#
+#   2. Shareable link — an admin creates an invitation WITHOUT an email in the
+#      custom attributes (optionally single_use: false for a reusable link).
+#      No email is sent; the admin copies the invitation's link
+#      (https://auth.nel.family/if/flow/nel-family-enrollment/?itoken=<uuid>)
+#      and shares it however they like. The recipient sets their own username
+#      and password.
+#
+# Either way the recipient lands on the enrollment flow, which requires a valid
+# invitation token (continue_flow_without_invitation: false), so the flow is not
+# open to the public — only people holding an invitation link can enroll.
+version: 1
+metadata:
+  name: nel-family-invitation-onboarding
+entries:
+  ##########################################################################
+  # Enrollment flow
+  ##########################################################################
+  - identifiers:
+      slug: nel-family-enrollment
+    id: flow
+    model: authentik_flows.flow
+    attrs:
+      name: nel.family enrollment
+      title: Welcome to nel.family — set up your account
+      designation: enrollment
+      authentication: require_unauthenticated
+
+  # Requires a valid invitation token (?itoken=...). fixed_data from the
+  # invitation is loaded into the flow context, pre-filling matching prompts.
+  - identifiers:
+      name: nel-family-enrollment-invitation
+    id: stage-invitation
+    model: authentik_stages_invitation.invitationstage
+    attrs:
+      continue_flow_without_invitation: false
+
+  ##########################################################################
+  # Prompt fields (single stage collecting everything)
+  ##########################################################################
+  - identifiers:
+      name: nel-family-enrollment-field-name
+    id: prompt-field-name
+    model: authentik_stages_prompt.prompt
+    attrs:
+      field_key: name
+      label: Full name
+      type: text
+      required: true
+      placeholder: Full name
+      placeholder_expression: false
+      order: 0
+
+  - identifiers:
+      name: nel-family-enrollment-field-username
+    id: prompt-field-username
+    model: authentik_stages_prompt.prompt
+    attrs:
+      field_key: username
+      label: Username
+      type: username
+      required: true
+      placeholder: Username
+      placeholder_expression: false
+      order: 1
+
+  - identifiers:
+      name: nel-family-enrollment-field-email
+    id: prompt-field-email
+    model: authentik_stages_prompt.prompt
+    attrs:
+      field_key: email
+      label: Email
+      type: email
+      required: true
+      placeholder: Email
+      placeholder_expression: false
+      order: 2
+
+  - identifiers:
+      name: nel-family-enrollment-field-password
+    id: prompt-field-password
+    model: authentik_stages_prompt.prompt
+    attrs:
+      field_key: password
+      label: Password
+      type: password
+      required: true
+      placeholder: Password
+      placeholder_expression: false
+      order: 3
+
+  - identifiers:
+      name: nel-family-enrollment-field-password-repeat
+    id: prompt-field-password-repeat
+    model: authentik_stages_prompt.prompt
+    attrs:
+      field_key: password_repeat
+      label: Password (repeat)
+      type: password
+      required: true
+      placeholder: Password (repeat)
+      placeholder_expression: false
+      order: 4
+
+  - identifiers:
+      name: nel-family-enrollment-prompt
+    id: stage-prompt
+    model: authentik_stages_prompt.promptstage
+    attrs:
+      fields:
+        - !KeyOf prompt-field-name
+        - !KeyOf prompt-field-username
+        - !KeyOf prompt-field-email
+        - !KeyOf prompt-field-password
+        - !KeyOf prompt-field-password-repeat
+
+  ##########################################################################
+  # Write the new user + log them in
+  ##########################################################################
+  - identifiers:
+      name: nel-family-enrollment-user-write
+    id: stage-user-write
+    model: authentik_stages_user_write.userwritestage
+    attrs:
+      user_creation_mode: always_create
+      user_type: internal
+      user_path_template: users/nel-family
+
+  - identifiers:
+      name: nel-family-enrollment-user-login
+    id: stage-user-login
+    model: authentik_stages_user_login.userloginstage
+
+  ##########################################################################
+  # Flow stage bindings
+  ##########################################################################
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf stage-invitation
+      order: 10
+    model: authentik_flows.flowstagebinding
+    attrs:
+      evaluate_on_plan: true
+      re_evaluate_policies: true
+
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf stage-prompt
+      order: 20
+    model: authentik_flows.flowstagebinding
+
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf stage-user-write
+      order: 30
+    model: authentik_flows.flowstagebinding
+
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf stage-user-login
+      order: 100
+    model: authentik_flows.flowstagebinding
+
+  ##########################################################################
+  # Auto-email on invitation creation.
+  #
+  # Bound to a (transport-less) notification rule so it is evaluated for every
+  # event; it filters to invitation model_created and, when the invitation
+  # carries a fixed "email", sends the onboarding link. It always returns False
+  # so no actual notification is dispatched — the email is the side effect.
+  # SMTP settings are read from authentik's runtime CONFIG (same global Migadu
+  # connection used elsewhere), so no credentials live in this blueprint.
+  ##########################################################################
+  - identifiers:
+      name: nel-family-invitation-autoemail
+    id: policy-autoemail
+    model: authentik_policies_expression.expressionpolicy
+    attrs:
+      expression: |
+        if "event" not in request.context:
+            return False
+        event = request.context["event"]
+        if event.action != "model_created":
+            return False
+        model = event.context.get("model", {})
+        if model.get("app") != "authentik_stages_invitation" or model.get("model_name") != "invitation":
+            return False
+
+        from authentik.stages.invitation.models import Invitation
+        from authentik.lib.config import CONFIG
+        from email.mime.text import MIMEText
+        import smtplib
+        import ssl
+
+        invitation = Invitation.objects.filter(pk=model.get("pk")).first()
+        if invitation is None:
+            return False
+        fixed_data = invitation.fixed_data or {}
+        recipient = fixed_data.get("email")
+        if not recipient:
+            # No target email -> this invitation is a shareable link; send nothing.
+            return False
+
+        flow_slug = invitation.flow.slug if invitation.flow else "nel-family-enrollment"
+        invite_url = f"https://auth.nel.family/if/flow/{flow_slug}/?itoken={invitation.pk}"
+        name = fixed_data.get("name") or "there"
+
+        body = (
+            f"<p>Hi {name},</p>"
+            "<p>An account is ready for you on nel.family. Use the link below to "
+            "choose a password and finish setting up your account:</p>"
+            f'<p><a href="{invite_url}">{invite_url}</a></p>'
+            "<p>If you weren't expecting this, you can safely ignore this email.</p>"
+        )
+
+        sender = CONFIG.get("email.from")
+        message = MIMEText(body, "html")
+        message["Subject"] = "Set up your nel.family account"
+        message["From"] = sender
+        message["To"] = recipient
+
+        host = CONFIG.get("email.host")
+        port = CONFIG.get_int("email.port")
+        username = CONFIG.get("email.username")
+        password = CONFIG.get("email.password")
+        context = ssl.create_default_context()
+
+        if CONFIG.get_bool("email.use_ssl", False):
+            server = smtplib.SMTP_SSL(host, port, context=context)
+        else:
+            server = smtplib.SMTP(host, port)
+            if CONFIG.get_bool("email.use_tls", False):
+                server.starttls(context=context)
+        try:
+            if username and password:
+                server.login(username, password)
+            server.sendmail(sender, [recipient], message.as_string())
+        finally:
+            server.quit()
+
+        ak_logger.info("Sent onboarding invitation email", recipient=recipient, flow=flow_slug)
+        return False
+
+  - identifiers:
+      name: nel-family-invitation-autoemail
+    id: rule-autoemail
+    model: authentik_events.notificationrule
+    attrs:
+      severity: notice
+
+  - identifiers:
+      target: !KeyOf rule-autoemail
+      policy: !KeyOf policy-autoemail
+      order: 0
+    model: authentik_policies.policybinding
+    attrs:
+      enabled: true

--- a/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
+++ b/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
@@ -1,24 +1,25 @@
-# Invitation-based onboarding with automatic email.
+# Invitation-based onboarding flow.
 #
-# This gives us two onboarding paths off a single enrollment flow:
+# This defines a single enrollment flow that an admin sends/shares on demand —
+# sending is an explicit admin action, never automatic:
 #
-#   1. Auto-emailed onboarding — an admin creates an invitation (Directory ->
-#      Invitations, or Flows & Stages -> Invitations) and fills the "Custom
-#      attributes" with at least {"email": "person@example.com"} (optionally
-#      "name" / "username"). The expression policy below fires on the
-#      invitation's model_created event and emails that person their personal
-#      onboarding link via the global Migadu SMTP. Zero extra admin clicks.
+#   Directory -> Invitations -> New Invitation -> select the "nel.family
+#   enrollment" flow, set Name / Expires / Single use, optionally Custom
+#   attributes {"email": "...", "name": "..."} to pre-fill the recipient's form.
 #
-#   2. Shareable link — an admin creates an invitation WITHOUT an email in the
-#      custom attributes (optionally single_use: false for a reusable link).
-#      No email is sent; the admin copies the invitation's link
-#      (https://auth.nel.family/if/flow/nel-family-enrollment/?itoken=<uuid>)
-#      and shares it however they like. The recipient sets their own username
-#      and password.
+# To deliver the link, the admin then either:
+#   * clicks the native "Send via Email" action on the invitation (authentik
+#     2026.5+ sends the link via the global Migadu SMTP), or
+#   * expands the invitation and copies "Link to use the invitation"
+#     (https://auth.nel.family/if/flow/nel-family-enrollment/?itoken=<uuid>) to
+#     share however they like.
 #
-# Either way the recipient lands on the enrollment flow, which requires a valid
-# invitation token (continue_flow_without_invitation: false), so the flow is not
-# open to the public — only people holding an invitation link can enroll.
+# The recipient lands on this flow, which requires a valid invitation token
+# (continue_flow_without_invitation: false), so it is not open to the public —
+# only people holding an invitation link can enroll.
+#
+# (For the Directory -> Users -> Create path, use the user's "Email recovery
+# link" action instead — see recovery-email.yaml.)
 version: 1
 metadata:
   name: nel-family-invitation-onboarding
@@ -172,103 +173,7 @@ entries:
       order: 100
     model: authentik_flows.flowstagebinding
 
-  ##########################################################################
-  # Auto-email on invitation creation.
-  #
-  # Bound to a (transport-less) notification rule so it is evaluated for every
-  # event; it filters to invitation model_created and, when the invitation
-  # carries a fixed "email", sends the onboarding link. It always returns False
-  # so no actual notification is dispatched — the email is the side effect.
-  # SMTP settings are read from authentik's runtime CONFIG (same global Migadu
-  # connection used elsewhere), so no credentials live in this blueprint.
-  ##########################################################################
-  - identifiers:
-      name: nel-family-invitation-autoemail
-    id: policy-autoemail
-    model: authentik_policies_expression.expressionpolicy
-    attrs:
-      expression: |
-        if "event" not in request.context:
-            return False
-        event = request.context["event"]
-        if event.action != "model_created":
-            return False
-        model = event.context.get("model", {})
-        if model.get("app") != "authentik_stages_invitation" or model.get("model_name") != "invitation":
-            return False
-
-        from authentik.stages.invitation.models import Invitation
-        from authentik.lib.config import CONFIG
-        from email.mime.text import MIMEText
-        import smtplib
-        import ssl
-
-        invitation = Invitation.objects.filter(pk=model.get("pk")).first()
-        if invitation is None:
-            return False
-        fixed_data = invitation.fixed_data or {}
-        recipient = fixed_data.get("email")
-        if not recipient:
-            # No target email -> this invitation is a shareable link; send nothing.
-            return False
-
-        flow_slug = invitation.flow.slug if invitation.flow else "nel-family-enrollment"
-        invite_url = f"https://auth.nel.family/if/flow/{flow_slug}/?itoken={invitation.pk}"
-        name = fixed_data.get("name") or "there"
-
-        body = (
-            f"<p>Hi {name},</p>"
-            "<p>An account is ready for you on nel.family. Use the link below to "
-            "choose a password and finish setting up your account:</p>"
-            f'<p><a href="{invite_url}">{invite_url}</a></p>'
-            "<p>If you weren't expecting this, you can safely ignore this email.</p>"
-        )
-
-        sender = CONFIG.get("email.from")
-        message = MIMEText(body, "html")
-        message["Subject"] = "Set up your nel.family account"
-        message["From"] = sender
-        message["To"] = recipient
-
-        host = CONFIG.get("email.host")
-        port = CONFIG.get_int("email.port")
-        username = CONFIG.get("email.username")
-        password = CONFIG.get("email.password")
-        context = ssl.create_default_context()
-
-        if CONFIG.get_bool("email.use_ssl", False):
-            server = smtplib.SMTP_SSL(host, port, context=context)
-        else:
-            server = smtplib.SMTP(host, port)
-            if CONFIG.get_bool("email.use_tls", False):
-                server.starttls(context=context)
-        try:
-            if username and password:
-                server.login(username, password)
-            server.sendmail(sender, [recipient], message.as_string())
-        finally:
-            server.quit()
-
-        ak_logger.info("Sent onboarding invitation email", recipient=recipient, flow=flow_slug)
-        return False
-
-  - identifiers:
-      name: nel-family-invitation-autoemail
-    id: rule-autoemail
-    model: authentik_events.notificationrule
-    attrs:
-      severity: notice
-
-  - identifiers:
-      target: !KeyOf rule-autoemail
-      policy: !KeyOf policy-autoemail
-      order: 0
-    model: authentik_policies.policybinding
-    attrs:
-      enabled: true
-
-  # No standing/seeded invitation is created here on purpose. Registration links
-  # are created on demand from the admin UI: Directory -> Invitations -> New
-  # Invitation -> select the "nel.family enrollment" flow, set Name / Expires /
-  # Single use, and (optionally) Custom attributes {"email": "..."} to trigger
-  # the auto-email policy above. Expand the row for "Link to use the invitation".
+  # Sending is intentionally a manual admin action — there is no auto-email
+  # policy. The admin creates an invitation and then either clicks the native
+  # "Send via Email" action (authentik 2026.5+) or copies the link to share.
+  # No standing/seeded invitation is created here; links are made on demand.

--- a/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
+++ b/nixos/whiskey/services/authentik/blueprints/invitation-onboarding.yaml
@@ -266,3 +266,34 @@ entries:
     model: authentik_policies.policybinding
     attrs:
       enabled: true
+
+  ##########################################################################
+  # Standing multi-use registration link.
+  #
+  # A single invitation that as many people as you like can use to self-register,
+  # valid until `expires`. Share the URL:
+  #
+  #   https://auth.nel.family/if/flow/nel-family-enrollment/?itoken=<uuid>
+  #
+  # Grab the real URL once from the admin UI: Flows & Stages -> Invitations ->
+  # nel-family-open-registration -> "Link to use the invitation" (the <uuid> is
+  # the invitation's primary key, assigned by authentik and stable across
+  # blueprint re-applies).
+  #
+  # fixed_data is empty, so the auto-email policy above intentionally skips it —
+  # no mail is sent when this invitation is (re)created.
+  #
+  # SECURITY: anyone holding this link can create an internal account while it is
+  # valid. To extend the window, bump `expires`. To revoke early, set `expires`
+  # to a past date or add `state: absent` to this entry and re-apply.
+  ##########################################################################
+  - identifiers:
+      name: nel-family-open-registration
+    id: invitation-open
+    model: authentik_stages_invitation.invitation
+    attrs:
+      flow: !KeyOf flow
+      single_use: false
+      expiring: true
+      expires: "2027-06-13T00:00:00Z"
+      fixed_data: {}

--- a/nixos/whiskey/services/authentik/blueprints/recovery-email.yaml
+++ b/nixos/whiskey/services/authentik/blueprints/recovery-email.yaml
@@ -1,0 +1,189 @@
+# Recovery flow with email verification — enables the admin-driven onboarding
+# we want: an admin creates a user in Directory -> Users, then clicks
+# "Email recovery link" on that user. The user receives an email (sent via the
+# global Migadu SMTP configured in authentik.nix, use_global_settings: true)
+# with a link that drops them straight into the password-set prompt.
+#
+# Vendored from authentik's blueprints/example/flows-recovery-email-verification.yaml
+# (version/2026.5.2) with two changes:
+#   1. The upstream `blueprints.goauthentik.io/instantiate: "false"` label is
+#      removed so blueprint discovery actually applies it.
+#   2. A brand patch is appended setting flow_recovery on the default brand —
+#      the admin "Email recovery link" action reads the recovery flow off the
+#      request brand, and the default brand does not set it.
+#
+# When the admin emails the link, the recovery token restores the user into the
+# flow context (is_restored), so the identification + email stages are skipped
+# and the user lands directly on "Change your password".
+version: 1
+metadata:
+  name: nel-family-recovery-email
+entries:
+  - identifiers:
+      slug: default-recovery-flow
+    id: flow
+    model: authentik_flows.flow
+    attrs:
+      name: Default recovery flow
+      title: Set your password
+      designation: recovery
+      authentication: require_unauthenticated
+  - identifiers:
+      name: default-recovery-field-password
+    id: prompt-field-password
+    model: authentik_stages_prompt.prompt
+    attrs:
+      field_key: password
+      label: Password
+      type: password
+      required: true
+      placeholder: Password
+      order: 0
+      placeholder_expression: false
+  - identifiers:
+      name: default-recovery-field-password-repeat
+    id: prompt-field-password-repeat
+    model: authentik_stages_prompt.prompt
+    attrs:
+      field_key: password_repeat
+      label: Password (repeat)
+      type: password
+      required: true
+      placeholder: Password (repeat)
+      order: 1
+      placeholder_expression: false
+  - identifiers:
+      name: default-recovery-skip-if-restored
+    id: default-recovery-skip-if-restored
+    model: authentik_policies_expression.expressionpolicy
+    attrs:
+      expression: |
+        return bool(request.context.get('is_restored', True))
+  - identifiers:
+      name: default-recovery-email
+    id: default-recovery-email
+    model: authentik_stages_email.emailstage
+    attrs:
+      use_global_settings: true
+      host: localhost
+      port: 25
+      username: ""
+      use_tls: false
+      use_ssl: false
+      timeout: 10
+      from_address: admin@nel.family
+      token_expiry: minutes=30
+      subject: Set up your nel.family account
+      template: email/password_reset.html
+      activate_user_on_success: true
+      recovery_max_attempts: 5
+      recovery_cache_timeout: minutes=5
+  - identifiers:
+      name: default-recovery-user-write
+    id: default-recovery-user-write
+    model: authentik_stages_user_write.userwritestage
+    attrs:
+      user_creation_mode: never_create
+  - identifiers:
+      name: default-recovery-identification
+    id: default-recovery-identification
+    model: authentik_stages_identification.identificationstage
+    attrs:
+      user_fields:
+        - email
+        - username
+  - identifiers:
+      name: default-recovery-user-login
+    id: default-recovery-user-login
+    model: authentik_stages_user_login.userloginstage
+  - identifiers:
+      name: Change your password
+    id: stages-prompt-password
+    model: authentik_stages_prompt.promptstage
+    attrs:
+      fields:
+        - !KeyOf prompt-field-password
+        - !KeyOf prompt-field-password-repeat
+      validation_policies: []
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-recovery-identification
+      order: 10
+    model: authentik_flows.flowstagebinding
+    id: flow-binding-identification
+    attrs:
+      evaluate_on_plan: true
+      re_evaluate_policies: true
+      policy_engine_mode: any
+      invalid_response_action: retry
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-recovery-email
+      order: 20
+    model: authentik_flows.flowstagebinding
+    id: flow-binding-email
+    attrs:
+      evaluate_on_plan: true
+      re_evaluate_policies: true
+      policy_engine_mode: any
+      invalid_response_action: retry
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf stages-prompt-password
+      order: 30
+    model: authentik_flows.flowstagebinding
+    attrs:
+      evaluate_on_plan: true
+      re_evaluate_policies: false
+      policy_engine_mode: any
+      invalid_response_action: retry
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-recovery-user-write
+      order: 40
+    model: authentik_flows.flowstagebinding
+    attrs:
+      evaluate_on_plan: true
+      re_evaluate_policies: false
+      policy_engine_mode: any
+      invalid_response_action: retry
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-recovery-user-login
+      order: 100
+    model: authentik_flows.flowstagebinding
+    attrs:
+      evaluate_on_plan: true
+      re_evaluate_policies: false
+      policy_engine_mode: any
+      invalid_response_action: retry
+  - identifiers:
+      policy: !KeyOf default-recovery-skip-if-restored
+      target: !KeyOf flow-binding-identification
+      order: 0
+    model: authentik_policies.policybinding
+    attrs:
+      negate: false
+      enabled: true
+      timeout: 30
+  - identifiers:
+      policy: !KeyOf default-recovery-skip-if-restored
+      target: !KeyOf flow-binding-email
+      order: 0
+    state: absent
+    model: authentik_policies.policybinding
+    attrs:
+      negate: false
+      enabled: true
+      timeout: 30
+
+  # Bind the recovery flow to the default brand. The admin "Email recovery link"
+  # action (and the "Forgot password?" link on the login screen) resolves the
+  # recovery flow from the request brand; default-brand.yaml does not set it.
+  # default-brand.yaml uses `state: created`, so it will not clobber this field.
+  - identifiers:
+      domain: authentik-default
+      default: true
+    model: authentik_brands.brand
+    attrs:
+      flow_recovery: !KeyOf flow


### PR DESCRIPTION
## Summary
Adds two authentik blueprint configurations to support admin-driven user onboarding workflows for the nel.family authentication system.

## Changes
- **recovery-email.yaml**: Implements a recovery flow enabling admins to create users in the Directory and send password-set links via email. The flow skips identification/email stages when a recovery token is present, dropping users directly into the password change prompt. Vendored from authentik's example blueprints (v2026.5.2) with modifications to enable blueprint discovery and bind the flow to the default brand.

- **invitation-onboarding.yaml**: Implements an enrollment flow for invitation-based user registration. Admins create invitations on-demand and share links (either via native email action or manual copy). Recipients must present a valid invitation token to access the flow, which collects name, username, email, and password before creating the user account and logging them in.

## Implementation Details
- Both blueprints use authentik's standard stage types (identification, email, prompt, user write, user login, invitation)
- Recovery flow includes an expression policy to skip early stages when a user is restored via recovery token
- Email stage configured to use global Migadu SMTP settings (`use_global_settings: true`)
- Invitation flow requires valid token (`continue_flow_without_invitation: false`) to prevent public access
- No automatic email sending in invitation flow—delivery is an explicit manual admin action

https://claude.ai/code/session_015JS2EpvxNTn9rfJ79ouw1k